### PR TITLE
Fixed custom entities pickup

### DIFF
--- a/src/support.cpp
+++ b/src/support.cpp
@@ -222,7 +222,7 @@ bool BotSupport::isMonster (edict_t *ent) {
 }
 
 bool BotSupport::isItem (edict_t *ent) {
-   return strncmp (ent->v.classname.chars (), "item", 4) == 0;
+   return !!(strstr (ent->v.classname.chars(), "item_"));
 }
 
 bool BotSupport::isPlayerVIP (edict_t *ent) {


### PR DESCRIPTION
⚠ `strstr ` should be used to check custom entities which have `item_` in classname, for example: `mod_item_custom`