### PR TITLE
Update control.cpp

### DIFF
--- a/src/control.cpp
+++ b/src/control.cpp
@@ -1688,6 +1688,10 @@ bool BotControl::executeMenus () {
 void BotControl::showMenu (int id) {
    static bool menusParsed = false;
 
+   // Temp fix: bot menu ignores translation on a dedicated server.
+   // Need to update m_ignoreTranslate. I guess it was unexpectedly changed to true somewhere else when m_ent is null.
+   m_ignoreTranslate = game.isDedicated() && game.isNullEntity(m_ent);
+   
    // make menus looks like we need only once
    if (!menusParsed) {
       for (auto &parsed : m_menus) {


### PR DESCRIPTION
Temp fix: bot menu ignores translation on a dedicated server.
Need to update m_ignoreTranslate before showing the menu. I guess it was changed to false somewhere else when m_ent is null.
Note that in the original version after I installed yapb and before I launched the server for the first time, the translation showed correctly. However, after I changed yb_language to eng, restarted the server, and changed it back to chs, the translation was ignored.
There might be a better fix since I am not familiar with your code.