### PR TITLE
fix: hostage code

### DIFF
--- a/inc/yapb.h
+++ b/inc/yapb.h
@@ -638,6 +638,7 @@ private:
    float m_timeDoorOpen {}; // time to next door open check
    float m_lastChatTime {}; // time bot last chatted
    float m_timeLogoSpray {}; // time bot last spray logo
+   float m_knifeAttackTime {}; // time to rush with knife (at the beginning of the round)
    float m_duckDefuseCheckTime {}; // time to check for ducking for defuse
    float m_frameInterval; // bot's frame interval
    float m_lastCommandTime; // time bot last thinked
@@ -1176,6 +1177,7 @@ extern ConVar cv_shoots_thru_walls;
 extern ConVar cv_debug;
 extern ConVar cv_debug_goal;
 extern ConVar cv_save_bots_names;
+extern ConVar cv_random_knife_attacks;
 
 extern ConVar mp_freezetime;
 extern ConVar mp_roundtime;

--- a/inc/yapb.h
+++ b/inc/yapb.h
@@ -638,7 +638,6 @@ private:
    float m_timeDoorOpen {}; // time to next door open check
    float m_lastChatTime {}; // time bot last chatted
    float m_timeLogoSpray {}; // time bot last spray logo
-   float m_knifeAttackTime {}; // time to rush with knife (at the beginning of the round)
    float m_duckDefuseCheckTime {}; // time to check for ducking for defuse
    float m_frameInterval; // bot's frame interval
    float m_lastCommandTime; // time bot last thinked

--- a/src/botlib.cpp
+++ b/src/botlib.cpp
@@ -35,6 +35,7 @@ ConVar cv_restricted_weapons ("yb_restricted_weapons", "", "Specifies semicolon 
 ConVar cv_attack_monsters ("yb_attack_monsters", "0", "Allows or disallows bots to attack monsters.");
 ConVar cv_pickup_custom_items ("yb_pickup_custom_items", "0", "Allows or disallows bots to pickup custom items.");
 ConVar cv_ignore_objectives ("yb_ignore_objectives", "0", "Allows or disallows bots to do map objectives, i.e. plant/defuse bombs, and saves hostages.");
+ConVar cv_random_knife_attacks ("yb_random_knife_attacks", "1", "Allows or disallows the ability for random knife attacks when bot is rushing and no enemy is nearby.");
 
 // game console variables
 ConVar mp_c4timer ("mp_c4timer", nullptr, Var::GameRef);
@@ -3067,6 +3068,16 @@ void Bot::normal_ () {
       return;
    }
 
+   // bots rushing with knife, when have no enemy (thanks for idea to nicebot project)
+   if (cv_random_knife_attacks.bool_ () && usesKnife () && (game.isNullEntity (m_lastEnemy) || !util.isAlive (m_lastEnemy)) && game.isNullEntity (m_enemy) && m_knifeAttackTime < game.time () && !hasShield () && numFriendsNear (pev->origin, 96.0f) == 0) {
+      if (rg.chance (40)) {
+         pev->button |= IN_ATTACK;
+      }
+      else {
+         pev->button |= IN_ATTACK2;
+      }
+      m_knifeAttackTime = game.time () + rg.get (2.5f, 6.0f);
+   }
    const auto &prop = conf.getWeaponProp (m_currentWeapon);
 
    if (m_reloadState == Reload::None && getAmmo () != 0 && getAmmoInClip () < 5 && prop.ammo1 != -1) {

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -123,7 +123,7 @@ void Game::levelInitialize (edict_t *entities, int max) {
       else if (strcmp (classname, "func_vip_safetyzone") == 0 || strcmp (classname, "info_vip_safetyzone") == 0) {
          m_mapFlags |= MapFlags::Assassination; // assassination map
       }
-      else if (strcmp (classname, "hostage_entity") == 0) {
+      else if (strcmp (classname, "hostage_entity") == 0 || strcmp (classname, "monster_scientist") == 0) {
          m_mapFlags |= MapFlags::HostageRescue; // rescue map
       }
       else if (strcmp (classname, "func_bomb_target") == 0 || strcmp (classname, "info_bomb_target") == 0) {

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -2751,6 +2751,7 @@ void BotGraph::addBasic () {
    autoCreateForEntity (NodeAddFlag::Goal, "func_bomb_target"); // bombspot zone
    autoCreateForEntity (NodeAddFlag::Goal, "info_bomb_target"); // bombspot zone (same as above)
    autoCreateForEntity (NodeAddFlag::Goal, "hostage_entity"); // hostage entities
+   autoCreateForEntity (NodeAddFlag::Goal, "monster_scientist"); // hostage entities (same as above)
    autoCreateForEntity (NodeAddFlag::Goal, "func_vip_safetyzone"); // vip rescue (safety) zone
    autoCreateForEntity (NodeAddFlag::Goal, "func_escapezone"); // terrorist escape zone
 }

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -1348,6 +1348,7 @@ void Bot::newRound () {
    m_flashLevel = 100.0f;
    m_checkDarkTime = game.time ();
 
+   m_knifeAttackTime = game.time () + rg.get (1.3f, 2.6f);
    m_nextBuyTime = game.time () + rg.get (0.6f, 2.0f);
 
    m_buyPending = false;

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -1348,7 +1348,6 @@ void Bot::newRound () {
    m_flashLevel = 100.0f;
    m_checkDarkTime = game.time ();
 
-   m_knifeAttackTime = game.time () + rg.get (1.3f, 2.6f);
    m_nextBuyTime = game.time () + rg.get (0.6f, 2.0f);
 
    m_buyPending = false;

--- a/src/navigate.cpp
+++ b/src/navigate.cpp
@@ -79,9 +79,7 @@ int Bot::findBestGoal () {
       return findGoalPost (tactic, defensiveNodes, offensiveNodes);
    }
    else if (m_team == Team::CT && hasHostage ()) {
-      tactic = 2;
-      offensiveNodes = &graph.m_rescuePoints;
-
+      tactic = 4;
       return findGoalPost (tactic, defensiveNodes, offensiveNodes);
    }
 
@@ -206,6 +204,31 @@ int Bot::findGoalPost (int tactic, IntArray *defensive, IntArray *offsensive) {
       }
       else {
          postprocessGoals (graph.m_goalPoints, goalChoices);
+      }
+   }
+   else if (tactic == 4 && !graph.m_rescuePoints.empty ()) // rescue goal
+   {
+      // force ct with hostage(s) to select closest rescue goal
+      float minDist = kInfiniteDistance;
+      int count = 0;
+
+      for (auto &point : graph.m_rescuePoints) {
+         float distance = graph[point].origin.distanceSq (pev->origin);
+
+         if (distance < minDist) {
+            goalChoices[count] = point;
+
+            if (++count > 3) {
+               count = 0;
+            }
+            minDist = distance;
+         }
+      }
+
+      for (auto &choice : goalChoices) {
+         if (choice == kInvalidNodeIndex) {
+             choice = graph.m_rescuePoints.random ();
+         }
       }
    }
 


### PR DESCRIPTION
This fixes some of the bot behaviour issues on maps with hostage rescue goal.

- Bots now reliably take hostages to the rescue node (goal)
- Bot now tries to take all nearby hostages at once
- Bots are not stealing hostages from human teammates anymore (hackish)
  - It's just a check to see if a human CT is near a hostage (inspiration from old PODBot code)
- Fixed Bot::seesItem method, so that bots no longer try to reach pickups (like hostages) through walls
- Added forgotten hostage entity 'monster_scientist' (some old Maps use this instead of 'hostage_entity')
- Removed ability for random knife attacks when bot is rushing and no enemies are nearby
  - Why? bots often kill hostages/teammates
  - It's of course possible to add some code that prevents bots from doing this, but I personally see no reason to let bots perform meaningless attacks...