### PR TITLE
fix: prevent dropping weapons on "Drop C4" command

### DIFF
--- a/src/botlib.cpp
+++ b/src/botlib.cpp
@@ -5378,11 +5378,11 @@ void Bot::dropWeaponForUser (edict_t *user, bool discardC4) {
       m_aimFlags |= AimFlags::Entity;
       m_lookAt = user->v.origin;
 
-      if (discardC4) {
+      if (discardC4 && m_hasC4) {
          selectWeaponByName ("weapon_c4");
          issueCommand ("drop");
       }
-      else {
+      else if (!discardC4) {
          selectBestWeapon ();
          issueCommand ("drop");
       }


### PR DESCRIPTION
But I've noticed that bots sometimes don't drop the bomb.

Apparently it's because of the argument `m_moneyAmount >= 2000`, so when the bot has less than $2000 left, it doesn't drop the bomb.