### PR TITLE
improve: use ScoreAttrib message to detect if bot is a VIP or not.

### DIFF
--- a/inc/message.h
+++ b/inc/message.h
@@ -31,7 +31,8 @@ CR_DECLARE_SCOPED_ENUM (NetMsg,
    FlashBat = 20,
    Fashlight = 21,
    ItemStatus = 22,
-   ScoreInfo = 23
+   ScoreInfo = 23,
+   ScoreAttrib = 24
 )
 
 // vgui menus (since latest steam updates is obsolete, but left for old cs)
@@ -118,6 +119,10 @@ private:
    void netMsgNVGToggle ();
    void netMsgFlashBat ();
    void netMsgScoreInfo ();
+   void netMsgScoreAttrib ();
+
+private:
+   Bot *pickBot (int32 index);
 
 public:
    MessageDispatcher ();

--- a/src/botlib.cpp
+++ b/src/botlib.cpp
@@ -3001,10 +3001,6 @@ void Bot::update () {
    m_team = game.getTeam (ent ());
    m_healthValue = cr::clamp (pev->health, 0.0f, 100.0f);
 
-   if (game.mapIs (MapFlags::Assassination) && !m_isVIP) {
-      m_isVIP = util.isPlayerVIP (ent ());
-   }
-
    if (m_team == Team::Terrorist && game.mapIs (MapFlags::Demolition)) {
       m_hasC4 = !!(pev->weapons & cr::bit (Weapon::C4));
 

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -1235,7 +1235,6 @@ void Bot::newRound () {
 
    m_navTimeset = game.time ();
    m_team = game.getTeam (ent ());
-   m_isVIP = false;
 
    resetPathSearchType ();
 
@@ -1243,7 +1242,6 @@ void Bot::newRound () {
    m_states = 0;
    clearTasks ();
 
-   m_isVIP = false;
    m_isLeader = false;
    m_hasProgressBar = false;
    m_canChooseAimDirection = true;


### PR DESCRIPTION
This should resolve problems with bot behavior, when plugins changes VIP player model to something else, and resolve issue #355.