### PR TITLE
fix: write "Official Navigation Graph" if graph author matches the product.name

### DIFF
--- a/src/support.cpp
+++ b/src/support.cpp
@@ -298,7 +298,7 @@ void BotSupport::checkWelcome () {
       StringRef graphAuthor = graph.getAuthor ();
       StringRef graphModified = graph.getModifiedBy ();
 
-      if (!graphAuthor.startsWith (product.folder)) {
+      if (!graphAuthor.startsWith (product.name)) {
          authorStr.assignf ("Navigation Graph by: %s", graphAuthor);
 
          if (!graphModified.empty ()) {


### PR DESCRIPTION
which was broken after the commit https://github.com/yapb/yapb/commit/a3288cc353ec65bb3c9a03ad611bfd4a72c4adab