### PR TITLE
fix: don't open the camp directions menu when removing the camp flag from a node created via the "Add Waypoint" menu

### DIFF
--- a/src/control.cpp
+++ b/src/control.cpp
@@ -1503,13 +1503,15 @@ int BotControl::menuGraphFlag (int item) {
    
    case 9:
       // if the node doesn't have a camp flag, set it and open the camp directions selection menu
-      if (graph[nearest].flags != NodeFlag::Camp) {
+      if (graph[nearest].flags == !(NodeFlag::Crossing && NodeFlag::Camp)) {
+         graph.toggleFlags (NodeFlag::Crossing);
          graph.toggleFlags (NodeFlag::Camp);
          showMenu (Menu::CampDirections);
          break;
       }
       // otherwise remove the flag, and don't show the camp directions selection menu
       else {
+         graph.toggleFlags (NodeFlag::Crossing);
          graph.toggleFlags (NodeFlag::Camp);
          showMenu (Menu::NodeFlag);
          break;

--- a/src/control.cpp
+++ b/src/control.cpp
@@ -1503,8 +1503,13 @@ int BotControl::menuGraphFlag (int item) {
    
    case 9:
       // if the node doesn't have a camp flag, set it and open the camp directions selection menu
-      if (graph[nearest].flags == !(NodeFlag::Crossing && NodeFlag::Camp)) {
+      if (!(graph[nearest].flags & NodeFlag::Crossing) && !(graph[nearest].flags & NodeFlag::Camp)) {
          graph.toggleFlags (NodeFlag::Crossing);
+         graph.toggleFlags (NodeFlag::Camp);
+         showMenu (Menu::CampDirections);
+         break;
+      }
+      else if ((graph[nearest].flags & NodeFlag::Crossing) && !(graph[nearest].flags & NodeFlag::Camp)) {
          graph.toggleFlags (NodeFlag::Camp);
          showMenu (Menu::CampDirections);
          break;


### PR DESCRIPTION
The "Add Waypoint" menu creates a camp node with the **crossing** flag. Because of this, on such nodes, when removing the camp flag, the camp directions selection menu was opened