### PR TITLE
fix: toggling t and ct important flags when there are other flags on the node

### DIFF
--- a/src/control.cpp
+++ b/src/control.cpp
@@ -1447,7 +1447,7 @@ int BotControl::menuGraphFlag (int item) {
       break;
 
    case 2:
-      if (graph[nearest].flags == NodeFlag::CTOnly) {
+      if (graph[nearest].flags & NodeFlag::CTOnly) {
          graph.toggleFlags (NodeFlag::CTOnly);
          graph.toggleFlags (NodeFlag::TerroristOnly);
       }
@@ -1458,7 +1458,7 @@ int BotControl::menuGraphFlag (int item) {
       break;
 
    case 3:
-      if (graph[nearest].flags == NodeFlag::TerroristOnly) {
+      if (graph[nearest].flags & NodeFlag::TerroristOnly) {
          graph.toggleFlags (NodeFlag::TerroristOnly);
          graph.toggleFlags (NodeFlag::CTOnly);
       }
@@ -1503,20 +1503,13 @@ int BotControl::menuGraphFlag (int item) {
    
    case 9:
       // if the node doesn't have a camp flag, set it and open the camp directions selection menu
-      if (!(graph[nearest].flags & NodeFlag::Crossing) && !(graph[nearest].flags & NodeFlag::Camp)) {
-         graph.toggleFlags (NodeFlag::Crossing);
-         graph.toggleFlags (NodeFlag::Camp);
-         showMenu (Menu::CampDirections);
-         break;
-      }
-      else if ((graph[nearest].flags & NodeFlag::Crossing) && !(graph[nearest].flags & NodeFlag::Camp)) {
+      if (!(graph[nearest].flags & NodeFlag::Camp)) {
          graph.toggleFlags (NodeFlag::Camp);
          showMenu (Menu::CampDirections);
          break;
       }
       // otherwise remove the flag, and don't show the camp directions selection menu
       else {
-         graph.toggleFlags (NodeFlag::Crossing);
          graph.toggleFlags (NodeFlag::Camp);
          showMenu (Menu::NodeFlag);
          break;


### PR DESCRIPTION
fix: removed unnecessary condition for toggling the camp flag
I realized how I can remove the camp flag from a node that has other flags without opening the camp direction selection menu.