### PR TITLE
Ignoring some parameters for throwing grenades.

### DIFF
--- a/inc/engine.h
+++ b/inc/engine.h
@@ -56,6 +56,7 @@ CR_DECLARE_SCOPED_ENUM (MapFlags,
    Escape = cr::bit (3),
    KnifeArena = cr::bit (4),
    FightYard = cr::bit (5),
+   GrenadeWar = cr::bit(6),
    HasDoors = cr::bit (10), // additional flags
    HasButtons = cr::bit (11) // map has buttons
 )

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -1861,7 +1861,17 @@ void Bot::checkGrenadesThrow () {
    };
 
    // check if throwing a grenade is a good thing to do...
-   if (preventibleTasks || isInNarrowPlace () || cv_ignore_enemies.bool_ () || m_isUsingGrenade || m_grenadeRequested || m_isReloading || (isKnifeMode () && !bots.isBombPlanted ()) || m_grenadeCheckTime >= game.time ()) {
+   auto throwingCondition = game.mapIs(MapFlags::GrenadeWar)
+      ? false
+      : (preventibleTasks
+         || isInNarrowPlace()
+         || cv_ignore_enemies.bool_()
+         || m_isUsingGrenade
+         || m_grenadeRequested
+         || m_isReloading
+         || (isKnifeMode() && !bots.isBombPlanted())
+         || m_grenadeCheckTime >= game.time());
+   if (throwingCondition) {
       clearThrowStates (m_states);
       return;
    }
@@ -1869,7 +1879,8 @@ void Bot::checkGrenadesThrow () {
    // check again in some seconds
    m_grenadeCheckTime = game.time () + kGrenadeCheckTime;
 
-   if (!util.isAlive (m_lastEnemy) || !(m_states & (Sense::SuspectEnemy | Sense::HearingEnemy))) {
+   auto senseCondition = game.mapIs(MapFlags::GrenadeWar) ? false : !(m_states & (Sense::SuspectEnemy | Sense::HearingEnemy));
+   if (!util.isAlive (m_lastEnemy) || senseCondition) {
       clearThrowStates (m_states);
       return;
    }
@@ -1911,7 +1922,10 @@ void Bot::checkGrenadesThrow () {
    }
 
    // enemy within a good throw distance?
-   if (!m_lastEnemyOrigin.empty () && distanceSq > cr::sqrf (grenadeToThrow == Weapon::Smoke ? 200.0f : 400.0f) && distanceSq < cr::sqrf (1200.0f)) {
+   auto grenadeToThrowCondition = game.mapIs(MapFlags::GrenadeWar)
+      ? 100.0f
+      : grenadeToThrow == Weapon::Smoke ? 200.0f : 400.0f;
+   if (!m_lastEnemyOrigin.empty () && distanceSq > cr::sqrf (grenadeToThrowCondition) && distanceSq < cr::sqrf (1200.0f)) {
       bool allowThrowing = true;
 
       // care about different grenades

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -158,6 +158,9 @@ void Game::levelInitialize (edict_t *entities, int max) {
       else if (prefix.startsWith ("ka_")) {
          m_mapFlags |= MapFlags::KnifeArena;
       }
+      else if (prefix.startsWith("he_")) {
+         m_mapFlags |= MapFlags::GrenadeWar;
+      }
    }
 
    // reset some timers

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -10,6 +10,7 @@
 ConVar cv_csdm_mode ("csdm_mode", "0", "Enables or disables CSDM / FFA mode for bots.\nAllowed values: '0', '1', '2', '3'.\nIf '0', CSDM / FFA mode is auto-detected.\nIf '1', CSDM mode is enabled, but FFA is disabled.\nIf '2', CSDM and FFA mode is enabled.\nIf '3', CSDM and FFA mode is disabled.", true, 0.0f, 3.0f);
 ConVar cv_ignore_map_prefix_game_mode ("ignore_map_prefix_game_mode", "0", "If enabled, bots will not apply game modes based on map name prefix (fy_ and ka_ specifically).");
 ConVar cv_threadpool_workers ("threadpool_workers", "-1", "Maximum number of threads bot will run to process some tasks. -1 means half of CPU cores used.", true, -1.0f, static_cast <float> (plat.hardwareConcurrency ()));
+ConVar cv_grenadier_mode("grenadier_mode", "0", "If enabled, bots will not apply  throwing condition on grenades.");
 
 ConVar sv_skycolor_r ("sv_skycolor_r", nullptr, Var::GameRef);
 ConVar sv_skycolor_g ("sv_skycolor_g", nullptr, Var::GameRef);
@@ -161,6 +162,10 @@ void Game::levelInitialize (edict_t *entities, int max) {
       else if (prefix.startsWith("he_")) {
          m_mapFlags |= MapFlags::GrenadeWar;
       }
+   }
+
+   if (cv_grenadier_mode.bool_()) {
+      m_mapFlags |= MapFlags::GrenadeWar;
    }
 
    // reset some timers

--- a/src/tasks.cpp
+++ b/src/tasks.cpp
@@ -1084,8 +1084,8 @@ void Bot::throwExplosive_ () {
 
    ignoreCollision ();
 
-   if (pev->origin.distanceSq (dest) < cr::sqrf (450.0f)) {
-      // heck, I don't wanna blow up myself
+   if (!game.mapIs(MapFlags::GrenadeWar) && (pev->origin.distanceSq (dest) < cr::sqrf (450.0f))) {
+   // heck, I don't wanna blow up myself
       m_grenadeCheckTime = game.time () + kGrenadeCheckTime * 2.0f;
 
       selectBestWeapon ();
@@ -1099,7 +1099,7 @@ void Bot::throwExplosive_ () {
       m_grenade = calcToss (pev->origin, dest);
    }
 
-   if (m_grenade.lengthSq () <= 100.0f) {
+   if (!game.mapIs(MapFlags::GrenadeWar) &&  (m_grenade.lengthSq () <= 100.0f)) {
       m_grenadeCheckTime = game.time () + kGrenadeCheckTime * 2.0f;
 
       selectBestWeapon ();


### PR DESCRIPTION
On maps with the "he_" prefix, bots will ignore the recommended distances (and Sense state) for throwing grenades.
Added new cvar "cv_grenadier_mode": if enabled, apply he_ maps condition on all