### PR TITLE
Set proper permissions for directories

### DIFF
--- a/package.py
+++ b/package.py
@@ -214,6 +214,8 @@ class BotRelease(object):
                tif = tarfile.TarInfo(name = zif.filename)
                tif.size = zif.file_size
                tif.mtime =  calendar.timegm(zif.date_time) - timeshift
+               if zif.is_dir():
+                    tif.mode = 0o755  # Set directory permissions (rwxr-xr-x)
                
                tarf.addfile(tarinfo = tif, fileobj = zipf.open(zif.filename))
                


### PR DESCRIPTION
The empty directories `logs`, `pwf`, and `train` extracted from the current Linux release archive (.tar.xz) have incorrect permissions (`drw-r--r--`). Without the execute (`x`) permission, the directories cannot be accessed under Linux.

In this PR, I set the correct directory permissions (`drwxr-xr-x`).