### PR TITLE
readme: fix the minimum supported version of Counter-Strike

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Latest YaPB](https://img.shields.io/github/v/release/yapb/yapb)](https://github.com/yapb/yapb/releases/latest) [![Latest YaPB](https://github.com/yapb/yapb/workflows/build/badge.svg)](https://github.com/yapb/yapb/actions) [![YaPB License](https://img.shields.io/github/license/yapb/yapb)](https://github.com/yapb/yapb/blob/master/LICENSE) [![Downloads](https://img.shields.io/github/downloads/yapb/yapb/total)](https://github.com/yapb/yapb/releases/latest)
 
 ## ☉ About
-It's a computer controlled players (bots) for the Counter-Strike b6.6 - 1.6 and Counter-Strike: Condition Zero. Bots allows you to play that games without connecting any game server or even without internet.
+It's a computer controlled players (bots) for the Counter-Strike b6.5 - 1.6 and Counter-Strike: Condition Zero. Bots allows you to play that games without connecting any game server or even without internet.
 
 ## ☉ Documentation
 * English: https://yapb.readthedocs.io/en/latest/


### PR DESCRIPTION
@jeefo в readme видимо ошибка, YaPB же ещё поддерживает Counter-Strike Beta 6.5.
Проверял на Xash3D FWGS 0.19.2, т.к. на Xash3D FWGS 0.21 эта версия кс кикает сразу при старте сервера за якобы "читы".

Вроде бы я ещё видел твой коммит год или полтора назад где было написано что исправлена поддержка CS Beta 6.5 или что-то в этом роде.

В документации, Counter-Strike Beta 6.5 была указана как минимально поддерживаемая версия игры уже давно, с самого начала её написания, тобой же.